### PR TITLE
Reduced calls to `solve()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MADMMplasso
 Title: Multi Variate Multi Response 'ADMM' with Interaction Effects
-Version: 0.0.0.9016
+Version: 0.0.0.9017
 Authors@R:
     c(
         person(

--- a/R/admm_MADMMplasso.R
+++ b/R/admm_MADMMplasso.R
@@ -110,6 +110,7 @@ admm_MADMMplasso <- function(beta0, theta0, beta, beta_hat, theta, rho1, X, Z, m
 
   SVD_D <- Diagonal(x = svd.w$d)
   R_svd <- (svd.w$u %*% SVD_D) / N
+  R_svd_inv <- solve(R_svd)
 
   rho <- rho1
   Big_beta11 <- V
@@ -155,8 +156,8 @@ admm_MADMMplasso <- function(beta0, theta0, beta, beta_hat, theta, rho1, X, Z, m
       part_z <- DD3 %*% t(W_hat)
       part_y <- DD3 %*% my_beta_jj
 
-      beta_hat_j <- solve(solve(R_svd) + (svd.w$tv) %*% part_z)
-      beta_hat_j <- beta_hat_j %*% ((svd.w$tv) %*% part_y)
+      beta_hat_j <- solve(R_svd_inv + svd.w$tv %*% part_z)
+      beta_hat_j <- beta_hat_j %*% (svd.w$tv %*% part_y)
       beta_hat_j <- part_z %*% beta_hat_j
       beta_hat_JJ <- part_y - beta_hat_j
       beta_hat_JJ <- matrix(beta_hat_JJ, ncol = 1)


### PR DESCRIPTION
Inspired by the conversation started by https://github.com/ocbe-uio/MADMMplasso/issues/17#issuecomment-2008739712, I've moved one call of `solve()` on `admm_MADMMplasso()` (legacy code) up one loop level. Computation savings aren't huge (5%, see below), but it's something.

```
MADMMplasso version 0.0.0.9016
Unit: seconds
          expr    min       lq     mean   median       uq      max neval
 MADMMplasso() 82.921 83.98975 89.64103 86.89477 93.31642 108.8523    10

MADMMplasso version 0.0.0.9017
Unit: seconds
          expr      min       lq    mean   median       uq      max neval
 MADMMplasso() 79.06337 80.83594 88.9196 88.10198 94.51792 111.9471    10
```

To reproduce, use [this script](https://gist.github.com/wleoncio/03802bd9886cc8da7b78b06b1f5b5145), remembering to update the path to the dataset (`CRC_data_300.rds`).
