### PR TITLE
Replaced `print()` with `cat()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MADMMplasso
 Title: Multi Variate Multi Response 'ADMM' with Interaction Effects
-Version: 0.0.0.9019
+Version: 0.0.0.9020
 Authors@R:
     c(
         person(

--- a/R/admm_MADMMplasso.R
+++ b/R/admm_MADMMplasso.R
@@ -324,7 +324,7 @@ admm_MADMMplasso <- function(beta0, theta0, beta, beta_hat, theta, rho1, X, Z, m
     }
 
     if (my_print) {
-      print(c(res_dual, e.dual, res_pri, e.primal))
+      cat(res_dual, e.dual, res_pri, e.primal)
     }
     if (res_pri <= e.primal && res_dual <= e.dual) {
       # Remove excess beta and nll

--- a/R/cv_MADMMplasso.R
+++ b/R/cv_MADMMplasso.R
@@ -25,7 +25,7 @@ cv_MADMMplasso <- function(fit, nfolds, X, Z, y, alpha = 0.5, lambda = fit$Lambd
   nfolds <- length(table(foldid))
 
   for (ii in 1:nfolds) {
-    print(c("fold,", ii))
+    cat("fold,", ii)
     oo <- foldid == ii
 
     ggg[[ii]] <- MADMMplasso(X = X[!oo, , drop = FALSE], Z = Z[!oo, , drop = FALSE], y = y[!oo, , drop = FALSE], alpha = alpha, my_lambda = lambda, lambda_min = 0.01, max_it = max_it, e.abs = e.abs, e.rel = e.rel, nlambda = length(lambda[, 1]), rho = rho, tree = TT, my_print = my_print, alph = alph, pal = pal, gg = gg, tol = tol, cl = cl, legacy)

--- a/R/hh_nlambda_loop.R
+++ b/R/hh_nlambda_loop.R
@@ -28,9 +28,8 @@ hh_nlambda_loop <- function(
       beta_hat <- my_values$beta_hat
       y_hat <- my_values$y_hat
     }
-    cost_time <- Sys.time() - start_time
     if (my_print) {
-      print(cost_time)
+      print(Sys.time() - start_time)
     }
     if (parallel && !pal) {
       beta <- my_values[[hh]]$beta
@@ -75,9 +74,9 @@ hh_nlambda_loop <- function(
 
     if (my_print) {
       if (hh == 1) {
-        print(c(hh, (n_main_terms[hh]), non_zero_theta[hh], obj1))
+        cat(hh, (n_main_terms[hh]), non_zero_theta[hh], obj1)
       } else {
-        print(c(hh, (n_main_terms[hh]), non_zero_theta[hh], obj[hh - 1], obj1))
+        cat(hh, (n_main_terms[hh]), non_zero_theta[hh], obj[hh - 1], obj1)
       }
     }
 


### PR DESCRIPTION
This should close issue #38 by finishing the conversion of as many `print()` statements to `cat()`, `message()`, `warning()` and `stop()` as possible. This allows for cleaner output and suppression of output by the user (which can significantly speed up computation).
