### PR TITLE
Removed auto-triggering of rhub check

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -10,10 +10,6 @@ name: R-hub
 run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"
 
 on:
-  push:
-    branches: []
-  pull_request:
-    branches: []
   workflow_dispatch:
     inputs:
       config:


### PR DESCRIPTION
This is redundant with the current checks, so we can just leave the YAML here for manual checks.
