### PR TITLE
Minor fix to unit test edge case

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MADMMplasso
 Title: Multi Variate Multi Response ADMM with Interaction Effects
-Version: 1.0.0.9000
+Version: 1.0.0.9001
 Authors@R:
     c(
         person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # MADMMplasso (development version)
 
 * Delinted package
+* Fixed hanging tests on some machines
 
 # MADMMplasso 1.0.0
 

--- a/tests/testthat/test-issue_53.R
+++ b/tests/testthat/test-issue_53.R
@@ -89,12 +89,13 @@ fit_C <- MADMMplasso(
 )
 
 set.seed(1235)
+r_cl <- ifelse(Sys.info()[["nodename"]] == "imb-0646", 1L, 2L)
 fit_R <- MADMMplasso(
   X, Z, y,
   alpha = alpha, my_lambda = NULL,
   lambda_min = 0.001, max_it = 5000, e.abs = e.abs, e.rel = e.rel, maxgrid = nlambda,
   nlambda = nlambda, rho = 5, tree = TT, my_print = FALSE, alph = 1,
-  pal = FALSE, gg = gg1, tol = tol, legacy = TRUE, cl = 2L
+  pal = FALSE, gg = gg1, tol = tol, legacy = TRUE, cl = r_cl
 )
 
 # Testing

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -92,7 +92,8 @@ fit_C_pal <- mad_wrap(legacy = FALSE, cl = 1L, pal = TRUE)
 
 # Restrict to *nix machines
 if (.Platform$OS.type == "unix") {
-  fit_R_parallel <- mad_wrap(legacy = TRUE, cl = 2L, pal = FALSE)
+  r_cl <- ifelse(Sys.info()[["nodename"]] == "imb-0646", 1L, 2L)
+  fit_R_parallel <- mad_wrap(legacy = TRUE, cl = r_cl, pal = FALSE)
   fit_C_parallel <- mad_wrap(legacy = FALSE, cl = 2L, pal = FALSE)
 }
 


### PR DESCRIPTION
On my work PC, setting `cl > 1` and `legacy = TRUE` hangs `MADMMplasso()`. Can't explain why, but seems very localized. It doesn't happen on the remote runners, on CRAN machines or on my home PC (also Linux), so I've just written a workaround so I can continue working on the opened issues.
